### PR TITLE
BLAS dotc

### DIFF
--- a/src/__init__.mojo
+++ b/src/__init__.mojo
@@ -5,5 +5,6 @@ from .level1.copy_device import *
 from .level1.rot_device import *
 from .level1.swap_device import *
 from .level1.dot_device import *
+from .level1.dotc_device import *
 from .level1.nrm2_device import *
 from .level1.iamax_device import *

--- a/src/level1/__init__.mojo
+++ b/src/level1/__init__.mojo
@@ -5,5 +5,6 @@ from .copy_device import *
 from .rot_device import *
 from .swap_device import *
 from .dot_device import *
+from .dotc_device import *
 from .nrm2_device import *
 from .iamax_device import *

--- a/src/level1/dotc_device.mojo
+++ b/src/level1/dotc_device.mojo
@@ -1,0 +1,80 @@
+from gpu import thread_idx, block_idx, block_dim, grid_dim
+from os.atomic import Atomic
+from memory import stack_allocation
+from gpu.host import DeviceContext
+from math import ceildiv
+from complex import ComplexScalar, ComplexFloat64
+
+comptime TBsize = 512
+
+# level1.dotc
+# computes the dot product of two vectors of complex numbers conj(x)' * y
+fn dotc_device[
+    BLOCK: Int,
+    dtype: DType
+](
+    n: Int,
+    x: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    incx: Int,
+    y: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    incy: Int,
+    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+):
+    if n < 1:
+        return
+
+    var global_i = block_dim.x * block_idx.x + thread_idx.x
+    var n_threads = grid_dim.x * block_dim.x
+    var local_i = thread_idx.x
+
+    shared_res = stack_allocation[
+        BLOCK,
+        ComplexScalar[DType.float64],
+        address_space = AddressSpace.SHARED
+    ]()
+
+    var thread_sum = ComplexFloat64(0, 0)
+    for i in range(global_i, n, n_threads):
+        x_val = ComplexFloat64(Scalar[DType.float64](x[i*incx*2]), Scalar[DType.float64](x[i*incx*2+1]))
+        y_val = ComplexFloat64(Scalar[DType.float64](y[i*incy*2]), Scalar[DType.float64](y[i*incy*2+1]))
+
+        thread_sum = thread_sum + (x_val.conj() * y_val)
+
+    shared_res[local_i] = thread_sum
+    barrier()
+
+    var stride = BLOCK // 2
+    while stride > 0:
+        if local_i < stride:
+            shared_res[local_i] = shared_res[local_i] + shared_res[local_i + stride]
+        barrier()
+        stride //= 2
+
+    if local_i == 0:
+        _ = Atomic[dtype].fetch_add(
+            UnsafePointer(to=output[0]),
+            Scalar[dtype](shared_res[0].re)
+        )
+        _ = Atomic[dtype].fetch_add(
+            UnsafePointer(to=output[1]),
+            Scalar[dtype](shared_res[0].im)
+        )
+
+
+fn blas_dotc[dtype: DType](
+    n: Int,
+    d_x: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    incx: Int,
+    d_y: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    incy: Int,
+    d_out: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    ctx: DeviceContext
+) raises:
+    comptime kernel = dotc_device[TBsize, dtype]
+    ctx.enqueue_function[kernel, kernel](
+        n, d_x, incx,
+        d_y, incy, d_out,
+        grid_dim=ceildiv(n, TBsize),
+        block_dim=TBsize,
+    )
+    ctx.synchronize()

--- a/test-level1.mojo
+++ b/test-level1.mojo
@@ -4,6 +4,7 @@ from gpu.host import DeviceContext
 from gpu import block_dim, grid_dim, thread_idx
 from layout import Layout, LayoutTensor
 from math import sqrt
+from complex import ComplexSIMD
 
 from src import *
 from random import rand, seed, random_float64
@@ -222,6 +223,69 @@ def dot_test[
             # print("expected:", sp_res)
             # may want to use assert_almost_equal with tolerance specified
             assert_almost_equal(res_mojo[0], sp_res_mojo, atol=atol)
+
+
+def dotc_test[
+    dtype: DType,
+    size:  Int
+]():
+    with DeviceContext() as ctx:
+        # print("[ dotc test", dtype, "]")
+        out = ctx.enqueue_create_buffer[dtype](2)
+        out.enqueue_fill(0)
+        a_device = ctx.enqueue_create_buffer[dtype](size*2)
+        a = ctx.enqueue_create_host_buffer[dtype](size*2)
+        b_device = ctx.enqueue_create_buffer[dtype](size*2)
+        b = ctx.enqueue_create_host_buffer[dtype](size*2)
+
+        # Generate two arrays of random numbers on CPU
+        generate_random_arr[dtype, size*2](a.unsafe_ptr(), -1, 1)
+        generate_random_arr[dtype, size*2](b.unsafe_ptr(), -1, 1)
+
+        ctx.enqueue_copy(a_device, a)
+        ctx.enqueue_copy(b_device, b)
+
+        blas_dotc[dtype](
+            size,
+            a_device.unsafe_ptr(), 1,
+            b_device.unsafe_ptr(), 1,
+            out.unsafe_ptr(),
+            ctx)
+
+        # Import SciPy and numpy
+        sp = Python.import_module("scipy")
+        np = Python.import_module("numpy")
+        sp_blas = sp.linalg.blas
+
+        # Move a and b to a SciPy-compatible array and run SciPy BLAS routine
+        py_a = Python.list()
+        py_b = Python.list()
+        for i in range(size):
+            py_a.append(np.complex64(a[i*2], a[i*2+1]))
+            py_b.append(np.complex64(b[i*2], b[i*2+1]))
+
+        var sp_res: PythonObject
+        # Scipy only supports one precision - cdotc
+        if dtype == DType.float32:
+            np_a = np.array(py_a, dtype=np.complex64)
+            np_b = np.array(py_b, dtype=np.complex64)
+            sp_res = sp_blas.cdotc(np_a, np_b)
+        elif dtype == DType.float64:
+            np_a = np.array(py_a, dtype=np.complex64)
+            np_b = np.array(py_b, dtype=np.complex64)
+            sp_res = sp_blas.cdotc(np_a, np_b)
+        else:
+            print(dtype , " is not supported by SciPy")
+            return
+
+        sp_res_mojo_real = Scalar[dtype](py=sp_res.real)
+        sp_res_mojo_imag = Scalar[dtype](py=sp_res.imag)
+        with out.map_to_host() as res_mojo:
+            # print("out:", res_mojo[0])
+            # print("expected:", sp_res)
+            # may want to use assert_almost_equal with tolerance specified
+            assert_almost_equal(res_mojo[0], sp_res_mojo_real, atol=atol)
+            assert_almost_equal(res_mojo[1], sp_res_mojo_imag, atol=atol)
 
 
 def iamax_test[
@@ -561,6 +625,12 @@ def test_dot():
     dot_test[DType.float32, 4096]()
     dot_test[DType.float64, 256]()
     dot_test[DType.float64, 4096]()
+
+def test_dotc():
+    dotc_test[DType.float32, 256]()
+    dotc_test[DType.float32, 4096]()
+    dotc_test[DType.float64, 256]()
+    dotc_test[DType.float64, 4096]()
 
 def test_iamax():
     iamax_test[DType.float32, 256]()


### PR DESCRIPTION
This is just my best guess at what we can do for complex numbers. I'm not sure if there's anything better, but I'd be glad to change to something else that's a bit more safe.

For now this code assumes the provided type is the base type of the complex number. So Float32 means a complex number with 2 Float32 components (real, imag). These are stored as `[real1, imag1, real2, imag2]`.

It doesn't look like there's a `DType` value for complex numbers so the constructor for a gpu buffer won't accept them directly.

Closes #14 