### PR TITLE
Add BSD-3-Clause license and citation files

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,0 +1,12 @@
+@misc{MojoBLAS2025,
+  title        = {{MojoBLAS}: A {GPU}-Accelerated {BLAS} Library in {Mojo}},
+  author       = {Melnichenko, Tatiana and
+                  Andershock, Alexa and
+                  Fernandez-Aleman, Gian and
+                  Mowry, Jackson and
+                  Roaten, Holden and
+                  Weston, Jonah},
+  year         = {2025},
+  howpublished = {\url{https://github.com/tdehoff/MojoBLAS}},
+  note         = {Developed as coursework at the University of Tennessee, Knoxville},
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,34 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+type: software
+title: "MojoBLAS"
+abstract: "A GPU-accelerated BLAS library written in Mojo, providing Level 1, 2, and 3 routines with multi-precision floating-point support for NVIDIA and AMD GPUs."
+authors:
+  - given-names: Tatiana
+    family-names: Melnichenko
+    affiliation: "University of Tennessee, Knoxville"
+  - given-names: Alexa
+    family-names: Andershock
+    affiliation: "University of Tennessee, Knoxville"
+  - given-names: Gian
+    family-names: Fernandez-Aleman
+    affiliation: "University of Tennessee, Knoxville"
+  - given-names: Jackson
+    family-names: Mowry
+    affiliation: "University of Tennessee, Knoxville"
+  - given-names: Holden
+    family-names: Roaten
+    affiliation: "University of Tennessee, Knoxville"
+  - given-names: Jonah
+    family-names: Weston
+    affiliation: "University of Tennessee, Knoxville"
+repository-code: "https://github.com/tdehoff/MojoBLAS"
+url: "https://github.com/tdehoff/MojoBLAS"
+license: BSD-3-Clause
+date-released: "2025-09-25"
+keywords:
+  - BLAS
+  - Mojo
+  - GPU
+  - linear algebra
+  - high performance computing

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) 2025, University of Tennessee, Knoxville
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the University of Tennessee, Knoxville nor the names of
+   its contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
Adds LICENSE (BSD-3-Clause, copyright University of Tennessee, Knoxville), CITATION.cff (GitHub citation integration), and CITATION.bib (BibTeX entry for direct use in papers). Authors ordered per README contributor list.